### PR TITLE
Remove annoying warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
 elixir:
-  - 1.2.2
+  - 1.5.1
 otp_release:
   - 18.2.1

--- a/lib/ip2location.ex
+++ b/lib/ip2location.ex
@@ -21,7 +21,7 @@ defmodule IP2Location do
   end
 
   def lookup(ip) when is_binary(ip) do
-    ip = String.to_char_list(ip)
+    ip = String.to_charlist(ip)
 
     case :inet.parse_address(ip) do
       { :ok, parsed } -> lookup(parsed)

--- a/lib/ip2location/database/loader.ex
+++ b/lib/ip2location/database/loader.ex
@@ -72,8 +72,11 @@ defmodule IP2Location.Database.Loader do
       ipv4:    { ipv4_count, ipv4_offset, column <<< 2 },
       offsets: calc_offsets(db_type)
     }
-    if ipv6_count > 0 do
-      meta = %{meta | ipv6: { ipv6_count, ipv6_offset, 16 + ((column - 1) <<< 2) } } 
+    
+    meta = if ipv6_count > 0 do
+      %{meta | ipv6: { ipv6_count, ipv6_offset, 16 + ((column - 1) <<< 2) } } 
+    else
+      meta
     end
 
     { meta, data }

--- a/mix.exs
+++ b/mix.exs
@@ -7,9 +7,9 @@ defmodule IP2Location.Mixfile do
      elixir: "~> 1.2",
      build_embedded:  Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     description: description,
-     package: package,
-     deps: deps]
+     description: description(),
+     package: package(),
+     deps: deps()]
   end
 
   def application do

--- a/test/fixtures/list.exs
+++ b/test/fixtures/list.exs
@@ -6,7 +6,7 @@ defmodule IP2Location.TestFixtures.List do
   end
 
   def fixture_path(fixture_name) do
-    {_, _, filename} = fixtures |> Enum.find(fn({n, _, _}) -> n == fixture_name end)
+    {_, _, filename} = fixtures() |> Enum.find(fn({n, _, _}) -> n == fixture_name end)
     localname(filename)
   end
 
@@ -19,7 +19,7 @@ defmodule IP2Location.TestFixtures.List do
         "unzip -u -qq #{Path.basename(url)} #{filename}"
       ] 
       |> Enum.join(" && ") 
-      |> String.to_char_list 
+      |> String.to_charlist 
       |> :os.cmd
     end
   end


### PR DESCRIPTION
```
warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name

warning: String.to_char_list/1 is deprecated, use String.to_charlist/1

warning: the variable "meta" is unsafe as it has been set inside one of: case, cond, receive, if, and, or, &&, ||. Please explicitly return the variable value instead.

warning: variable "fixtures" does not exist and is being expanded to "fixtures()", please use parentheses to remove the ambiguity or change the variable name

warning: String.to_char_list/1 is deprecated, use String.to_charlist/1
```